### PR TITLE
Update light.css

### DIFF
--- a/theme/colors/light.css
+++ b/theme/colors/light.css
@@ -100,7 +100,7 @@
 	/* Elements */
 	--gnome-border-color: color-mix(in srgb, currentColor 15%, transparent);
 	--gnome-hover-color: color-mix(in srgb, currentColor 7%, transparent);
-	--gnome-active-color: color-mix(in srgb, currentColor 16%, transparent);
+	--gnome-active-color: color-mix(in srgb, currentColor 7%, transparent);
 	--gnome-selected-color: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-selected-hover-color: color-mix(in srgb, currentColor 13%, transparent);
 	--gnome-selected-active-color: color-mix(in srgb, currentColor 19%, transparent);


### PR DESCRIPTION
Fixed `--gnome-active-color` transparency values to be closer to libadwaita, examples below:

<img width="336" height="222" alt="Screenshot From 2025-07-20 12-04-32" src="https://github.com/user-attachments/assets/7421962b-b90e-47de-92a9-0deede5801f5" />
<img width="313" height="244" alt="image" src="https://github.com/user-attachments/assets/0afbdcc7-0a6c-402a-b809-e64b82465ffc" />
