### PR TITLE
Add new Flatpak location

### DIFF
--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -8,6 +8,7 @@ installationPaths=(
     ~/.var/app/org.mozilla.Thunderbird/.thunderbird
     ~/snap/thunderbird/common/.thunderbird
     ~/.var/app/eu.betterbird.Betterbird/.thunderbird
+    ~/.var/app/net.thunderbird.Thunderbird/.thunderbird
 )
 
 currentTheme=$(gsettings get org.gnome.desktop.interface gtk-theme ) || currentTheme=""


### PR DESCRIPTION
Add new Flatpak location: `~/.var/app/net.thunderbird.Thunderbird/.thunderbird`

Additional context:
- https://gitlab.com/fedora/sigs/flatpak/fedora-flatpaks/-/issues/50
- https://src.fedoraproject.org/rpms/thunderbird/c/8e08ed42a33c661d8c122e30b2d4dd2ec399187b
- https://bugzilla.redhat.com/show_bug.cgi?id=2210038

Tested and confirmed it installed correctly on my machine after adding this to the installationPaths.