### PR TITLE
fix(tabs): restore tab close buttons

### DIFF
--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -215,8 +215,8 @@ tab:not([soundplaying], [muted], [activemedia-blocked], [crashed]) .tab-icon-sta
 
 /* Close tab button */
 .tab-close-button {
-	content: url("../icons/window-close-symbolic.svg") !important;
-	fill: var(--gnome-toolbar-color) !important;
+	content: var(--gnome-icon-window-close-symbolic) !important;
+	fill: var(--gnome-toolbar-icon-fill) !important;
 	fill-opacity: 1 !important;
 	-moz-context-properties: fill, fill-opacity !important;
 	height: 16px !important;
@@ -236,8 +236,9 @@ tab:hover .tab-close-button {
 	opacity: 1 !important;
 }
 
-/* Fix close button position */
-#tabbrowser-tabs[closebuttons="activetab"] .tabmail-tab:not([pinned]) .tab-close-button {
+/* Show close button on inactive tabs too (Thunderbird hides it when
+ * closebuttons="activetab", except the first tab which can't be closed) */
+#tabmail-tabs[closebuttons="activetab"] .tabmail-tab:not([pinned], :first-child) .tab-close-button {
 	display: block !important;
 }
 


### PR DESCRIPTION
## Summary

Tab close buttons were broken in two ways (#29):

1. **The close icon never rendered** — `tabsbar.css` still loaded `../icons/window-close-symbolic.svg`, which was removed in the icons rework (daa08cf). Hovering the close button only showed an empty circle (its hover background). Now uses the existing `--gnome-icon-window-close-symbolic` variable.

2. **The icon rendered black instead of the theme color** — `fill` referenced `--gnome-toolbar-color`, which was dropped in the Firefox theme colors sync (5694886), so the SVG fell back to its default black fill. Now uses `--gnome-toolbar-icon-fill` (white in dark, #2f2f2f in light), matching other toolbar icons.

3. **Inactive tabs had no close button at all** — when tabs are narrower than `mail.tabs.tabClipWidth` (140px), Thunderbird sets `closebuttons="activetab"` on `#tabmail-tabs` and hides close buttons on unselected tabs with `display: none`. The override targeted Firefox's `#tabbrowser-tabs` ID, which doesn't exist in Thunderbird. Now targets `#tabmail-tabs`, still excluding the first tab (the primary Mail tab, which can't be closed) and pinned tabs.

Verified on Thunderbird 151.0.1.

Fixes #29